### PR TITLE
Fix country mapping link

### DIFF
--- a/how-it-works/geo.md
+++ b/how-it-works/geo.md
@@ -10,7 +10,7 @@ Countries are assigned to works using the affiliations that authors claim. For e
 
 ## Continents
 
-Countries are mapped to continents using data from the [United Nations Statistics Division](https://unstats.un.org/unsd/methodology/m49/). You can see the actual mapping used by the API [here](https://github.com/ourresearch/openalex-elastic-api/blob/master/countries.py).
+Countries are mapped to continents using data from the [United Nations Statistics Division](https://unstats.un.org/unsd/methodology/m49/). You can see the actual mapping used by the API [here](https://github.com/ourresearch/openalex-elastic-api/blob/master/country_list.py).
 
 ## Regions
 


### PR DESCRIPTION
The [Geo documentation page](https://help.openalex.org/how-it-works/geo) had an outdated country mapping link. This PR replaces fixes this.